### PR TITLE
Change / Remove Incorrect Presidio Recognizers

### DIFF
--- a/internal/core/presidio.go
+++ b/internal/core/presidio.go
@@ -30,14 +30,12 @@ type PatternRecognizer struct {
 }
 
 var entitiesMap = map[string]string{
-	"LOCATION":                        "ADDRESS",
 	"UsLicenseRecognizer":             "VIN", // AKA US_DRIVER_LICENSE
-	"PHONE_NUMBER":                    "PHONENUMBER",
-	"DATE_TIME":                       "DATE",
-	"EMAIL_ADDRESS":                   "EMAIL",
+	"DateRecognizer":                  "DATE",
+	"EmailRecognizer":                 "EMAIL",
 	"CreditCardRecognizer":            "CARD_NUMBER",
 	"UsSsnRecognizer":                 "SSN",
-	"URL":                             "URL",
+	"UrlRecognizer":                   "URL",
 	"UsPassportRecognizer":            "ID_NUMBER",
 	"UsItinRecognizer":                "ID_NUMBER",
 	"UsBankRecognizer":                "ID_NUMBER",

--- a/internal/core/presidio_test.go
+++ b/internal/core/presidio_test.go
@@ -35,7 +35,7 @@ func TestRecognize(t *testing.T) {
 			RContext: " and visa permit 564",
 		},
 		{
-			Label:    "EmailRecognizer",
+			Label:    "EMAIL",
 			Text:     "sonia41@example.net",
 			Start:    264,
 			End:      283,
@@ -43,7 +43,7 @@ func TestRecognize(t *testing.T) {
 			RContext: " for more.",
 		},
 		{
-			Label:    "UrlRecognizer",
+			Label:    "URL",
 			Text:     "example.net",
 			Start:    272,
 			End:      283,


### PR DESCRIPTION
The names of some recognizers were incorrect hence, the mapping was incorrect too. Also, the code used to to generate the patterns in the file `pattern.py` does not generate recognizers for tags like `PHONENUMBER`. They are modules of their own inside python presidio. 