### PR TITLE
Fix preload loading

### DIFF
--- a/electron-ner-app/preload.js
+++ b/electron-ner-app/preload.js
@@ -1,17 +1,4 @@
 // preload.js
-const { contextBridge, ipcRenderer } = require('electron');
-const { FIXED_PORT } = require('./scripts/check-port');
-
-// Expose API information to the renderer process
-contextBridge.exposeInMainWorld('electronAPI', {
-  // Backend API connection information
-  backendAPI: {
-    baseUrl: `http://localhost:${FIXED_PORT}`,  // Use our fixed port for backend URL
-    apiVersion: 'v1',
-  },
-  // You can add more IPC functions here if needed for direct Electron communication
-});
-
 window.addEventListener('DOMContentLoaded', () => {
   const replaceText = (selector, text) => {
     const element = document.getElementById(selector);


### PR DESCRIPTION
https://stackoverflow.com/questions/77456201/electron-not-loading-preload-script-when-application-is-built
Preload should only import (`require`) electron. We can simply remove the `check-port.js` import and the code that depends on it because it is deprecated anyway. It was used when we deployed the frontend directly with Vite, not with static serving.