### PR TITLE
Fix file-progress for probing the backend until the job is completed.

### DIFF
--- a/frontend/app/token-classification/jobs/page.tsx
+++ b/frontend/app/token-classification/jobs/page.tsx
@@ -28,7 +28,7 @@ import { floor } from 'lodash';
 const calculateProgress = (report: Report | null): number => {
   if (!report || !report.CompletedFileCount || !report.FileCount) return 0;
 
-  return floor((report.CompletedFileCount / report.FileCount) * 100);
+  return floor(((report.CompletedFileCount) / report.FileCount) * 100);
 };
 
 // Get the total number of processed tokens
@@ -277,11 +277,10 @@ function JobDetail() {
     const pollInterval = setInterval(async () => {
       await fetchTags();
 
-      const currentProgress = calculateProgress(reportData);
-
-      if (currentProgress === 100) {
+      if (reportData && (reportData.CompletedFileCount + reportData.FailedFileCount === reportData.FileCount)) {
         clearInterval(pollInterval);
       }
+
     }, 1000);
 
     return () => {


### PR DESCRIPTION
The frontend was invoking the backend each second to get the progress of the job. For this, the frontend was checking of the number of completed files is equal to the number of total files. But the number of completed files actually refers to the number of successful files, and the backend also send the number of failed files. In this PR, the frontend checks if `completedFileCount` + `failedFileCount` == `totalFileCount`.

[Jira Ticket](https://3rdai.atlassian.net/jira/software/projects/NC/boards/43?assignee=712020%3A905538cf-9530-4eac-b526-19e308fbdd72&selectedIssue=NC-129)