### PR TITLE
Token with feedback

### DIFF
--- a/frontend/app/token-classification/jobs/(database-table)/TableContent.tsx
+++ b/frontend/app/token-classification/jobs/(database-table)/TableContent.tsx
@@ -319,7 +319,7 @@ export function TableContent({
       ) : (
         filteredRecords.map((record, index) => {
           const fileIdentifier = record.sourceObject;
-          console.log("File identifier...", fileIdentifier);
+          console.log('File identifier...', fileIdentifier);
           const { fullPath, openFile } = handleFullPath(fileIdentifier);
           const tokens = record.taggedTokens.flatMap((token) => {
             const [text, tag] = token;

--- a/frontend/components/feedback/FeedbackPanel.tsx
+++ b/frontend/components/feedback/FeedbackPanel.tsx
@@ -142,7 +142,9 @@ export const FeedbackPanel: React.FC<FeedbackPanelProps> = ({
         {/* Collapsed bar */}
         {collapsed ? (
           <>
-            <span className="text-base font-semibold text-white">Feedback{feedbacks.length > 1 && 's'} ({feedbacks.length})</span>
+            <span className="text-base font-semibold text-white">
+              Feedback{feedbacks.length > 1 && 's'} ({feedbacks.length})
+            </span>
             <svg
               width="20"
               height="20"
@@ -204,10 +206,11 @@ export const FeedbackPanel: React.FC<FeedbackPanelProps> = ({
             {/* Submit button */}
             <div className="px-4 pb-4 flex-shrink-0">
               <button
-                className={`w-full text-white border rounded-md py-2 text-base font-medium transition shadow-md ${isSubmitting
-                  ? 'bg-blue-400 cursor-not-allowed'
-                  : 'bg-blue-600 hover:bg-blue-700 border-blue-700'
-                  }`}
+                className={`w-full text-white border rounded-md py-2 text-base font-medium transition shadow-md ${
+                  isSubmitting
+                    ? 'bg-blue-400 cursor-not-allowed'
+                    : 'bg-blue-600 hover:bg-blue-700 border-blue-700'
+                }`}
                 onClick={handleSubmit}
                 style={{ position: 'relative', zIndex: 10 }}
                 disabled={isSubmitting}

--- a/frontend/components/feedback/TokenHighlighter.tsx
+++ b/frontend/components/feedback/TokenHighlighter.tsx
@@ -39,7 +39,7 @@ export const TokenHighlighter: React.FC<TokenHighlighterProps> = ({
   spotlightEndIndex,
   editable = false,
   onTagAssign,
-  objectId
+  objectId,
 }) => {
   const [selectionStart, setSelectionStart] = useState<number | null>(null);
   const [selectionEnd, setSelectionEnd] = useState<number | null>(null);
@@ -143,20 +143,21 @@ export const TokenHighlighter: React.FC<TokenHighlighterProps> = ({
 
   const reportId = getReportId();
   const FEEDBACK_STORAGE_KEY = `feedback-${reportId}`;
-  const initialFeedback: Feedback[] = JSON.parse(localStorage.getItem(FEEDBACK_STORAGE_KEY) || '[]');
+  const initialFeedback: Feedback[] = JSON.parse(
+    localStorage.getItem(FEEDBACK_STORAGE_KEY) || '[]'
+  );
 
   function isFeedbackGiven(start: number, end: number, text: string, objectId: string) {
-    // console.log("Hue Hue");
     for (let index = 0; index < initialFeedback.length; index++) {
       const feedback = initialFeedback[index];
 
-      const isTokenMatched = feedback.body.objectId === objectId &&
+      const isTokenMatched =
+        feedback.body.objectId === objectId &&
         feedback.body.startIndex === start &&
         feedback.body.endIndex === end &&
         feedback.body.highlightedText === text;
 
       if (isTokenMatched) {
-
         return true;
       }
     }
@@ -177,8 +178,7 @@ export const TokenHighlighter: React.FC<TokenHighlighterProps> = ({
             spotlightEndIndex &&
             index >= spotlightStartIndex &&
             index <= spotlightEndIndex;
-          // const thisStart = start;
-          // start += token.text.length;
+
           return (
             <span
               key={index}
@@ -198,11 +198,21 @@ export const TokenHighlighter: React.FC<TokenHighlighterProps> = ({
               }}
               onMouseDown={() => handleMouseDown(index)}
             >
-              <span style={{
-                textDecoration: objectId && isFeedbackGiven(index, index, token.text, objectId) ? 'underline' : 'none',
-                textDecorationColor: objectId && isFeedbackGiven(index, index, token.text, objectId) ? '#0000EE' : 'none',
-                textDecorationThickness: '2px',
-              }}>{token.text}</span>
+              <span
+                style={{
+                  textDecoration:
+                    objectId && isFeedbackGiven(index, index, token.text, objectId)
+                      ? 'underline'
+                      : 'none',
+                  textDecorationColor:
+                    objectId && isFeedbackGiven(index, index, token.text, objectId)
+                      ? '#0000EE'
+                      : 'none',
+                  textDecorationThickness: '2px',
+                }}
+              >
+                {token.text}
+              </span>
 
               {token.tag !== 'O' &&
                 (index === tokens.length - 1 || tokens[index + 1]?.tag !== token.tag) && (
@@ -211,7 +221,7 @@ export const TokenHighlighter: React.FC<TokenHighlighterProps> = ({
                     style={{
                       backgroundColor: tagColors[token.tag]?.tag || DEFAULT_COLOR.tag,
                       color: 'white',
-                      textDecoration: 'none'
+                      textDecoration: 'none',
                     }}
                   >
                     {token.tag}

--- a/frontend/components/feedback/useFeedbackState.tsx
+++ b/frontend/components/feedback/useFeedbackState.tsx
@@ -20,7 +20,6 @@ export interface FeedbackMetadata {
 // TODO: Common function for tokenizing objects
 
 const useFeedbackState = (modelId: string, reportId: string) => {
-  console.log("Report Id", reportId);
   const FEEDBACK_STORAGE_KEY = `feedback-${reportId}`;
   const OBJECTS_STORAGE_KEY = `objects-${reportId}`;
 
@@ -44,11 +43,10 @@ const useFeedbackState = (modelId: string, reportId: string) => {
     objectTokens: string[],
     objectTags: string[]
   ) => {
-
     const { tag: _, ...feedbackWithoutTag } = newFeedback;
 
     // Check for duplicate feedback and remove existing entries
-    const updatedFeedback = feedback.filter(existingFeedback => {
+    const updatedFeedback = feedback.filter((existingFeedback) => {
       const { tag: __, ...existingFeedbackWithoutTag } = existingFeedback.body;
 
       const isDuplicate =


### PR DESCRIPTION
Token is being underlined if we have added a feedback for that, and not submitted. 
Why we need this?
-> So, the panel to look for feedbacks is very small, and user will face little difficulty in finding for a particular token in that panel that wether he gave the feedback or not. But if we will differentiate it from the other tokens then it will eliminate the issue. 
I am open to UI suggestions, right now I am just underlining the tokens.
