### PR TITLE
Add a banner on the reports dashboard page for quota usage

### DIFF
--- a/frontend/app/token-classification/jobs.tsx
+++ b/frontend/app/token-classification/jobs.tsx
@@ -452,10 +452,6 @@ export default function Jobs() {
       setQuotaUsedPercentage(
         (license.LicenseInfo.Usage.UsedBytes / license.LicenseInfo.Usage.MaxBytes) * 100
       );
-      console.log(
-        'Quota Used Percentage:',
-        (license.LicenseInfo.Usage.UsedBytes / license.LicenseInfo.Usage.MaxBytes) * 100
-      );
     }
   }, [reports]);
 


### PR DESCRIPTION
Add a banner on the reports dashboard page when >75% of the free-tier quota is exhausted.
<img width="1082" alt="Screenshot 2025-06-18 at 5 26 06 PM" src="https://github.com/user-attachments/assets/736d965d-d411-4fae-bd7d-0e1dace0a252" />
