### PR TITLE
License bug

### DIFF
--- a/frontend/app/token-classification/jobs.tsx
+++ b/frontend/app/token-classification/jobs.tsx
@@ -411,7 +411,7 @@ export default function Jobs() {
       Page: 'Reports Dashboard Page',
     });
   }, []);
-  console.log('license', license, 'isLicenseValid', isLicenseValid);
+
   useEffect(() => {
     let licenceValidityCheck = true;
     if (license && license.LicenseError) {


### PR DESCRIPTION
During each refresh or url change frontend fetches the license details, and the duration for which license was "null" it shows the invalid license error. 
It was a bad user experience to see some error each time for some mili-seconds.
The fix was, while licence is null, treat it as the user is having valid licence. And if the conditions go against the user, then only show the error message.