### PR TITLE
Only supported files will show up in frontend.

### DIFF
--- a/frontend/app/token-classification/jobs/new/page.tsx
+++ b/frontend/app/token-classification/jobs/new/page.tsx
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/input';
 import { SearchIcon } from '@heroicons/react/solid';
 import { useConditionalTelemetry } from '@/hooks/useConditionalTelemetry';
 import { useEnterprise } from '@/hooks/useEnterprise';
+import toast, { Toaster } from 'react-hot-toast';
 
 import { nerBaseUrl } from '@/lib/axios.config';
 
@@ -315,6 +316,18 @@ const FileSources: React.FC<FileSourcesProps> = ({
           SUPPORTED_TYPES.some((ext) => file.name.toLowerCase().endsWith(ext))
         );
         if (supportedFiles.length === 0) {
+          toast.error(
+            `No supported files selected. Only ${SUPPORTED_TYPES.join(', ')} files are allowed.`,
+            {
+              duration: 5000,
+              style: {
+                background: '#f44336',
+                color: '#fff',
+                padding: '10px',
+                borderRadius: '8px',
+              },
+            }
+          );
           setIsLoadingFiles(false);
           e.target.value = '';
           return;
@@ -1043,6 +1056,7 @@ export default function NewJobPage() {
 
   return (
     <div className="container px-4 py-8" style={{ width: '90%' }}>
+      <Toaster position="top-right" />
       {/* Title and Back Button */}
       <div className="flex items-center justify-between mb-6">
         <Button variant="outline" size="sm" asChild>


### PR DESCRIPTION
Unsupported file types such as `.png` were being shown in the file picker and also being sent to the backend. This filters the files to only take the supported ones.

Before:
<img width="1205" height="268" alt="Screenshot 2025-07-16 at 9 45 12 PM" src="https://github.com/user-attachments/assets/3d135869-b38a-4dd8-9ac8-d0bced8ba3e0" />


After: 
<img width="1232" height="304" alt="Screenshot 2025-07-16 at 9 44 39 PM" src="https://github.com/user-attachments/assets/e06e708e-0b56-4207-ac2a-1338a91af597" />
